### PR TITLE
Add Blaze minidrone in DRONE_PREFIXES

### DIFF
--- a/lib/MiniDroneBtAdapter.js
+++ b/lib/MiniDroneBtAdapter.js
@@ -36,7 +36,7 @@ const CHARACTERISTIC_MAP = [
 
 // Drone IDs
 const MANUFACTURER_SERIALS = ['4300cf1900090100', '4300cf1909090100', '4300cf1907090100'];
-const DRONE_PREFIXES = ['RS_', 'Mars_', 'Travis_', 'Maclan_', 'Blaze_'];
+const DRONE_PREFIXES = ['RS_', 'Mars_', 'Travis_', 'Maclan_', 'Blaze_', 'NewZ_'];
 const MD_DEVICE_TYPE = 0x02;
 
 const FLIGHT_STATUSES = ['landed', 'taking off', 'hovering', 'flying',

--- a/lib/MiniDroneBtAdapter.js
+++ b/lib/MiniDroneBtAdapter.js
@@ -36,7 +36,7 @@ const CHARACTERISTIC_MAP = [
 
 // Drone IDs
 const MANUFACTURER_SERIALS = ['4300cf1900090100', '4300cf1909090100', '4300cf1907090100'];
-const DRONE_PREFIXES = ['RS_', 'Mars_', 'Travis_', 'Maclan_'];
+const DRONE_PREFIXES = ['RS_', 'Mars_', 'Travis_', 'Maclan_', 'Blaze_'];
 const MD_DEVICE_TYPE = 0x02;
 
 const FLIGHT_STATUSES = ['landed', 'taking off', 'hovering', 'flying',


### PR DESCRIPTION
After trying the lib, I discover that my minidrone [Blaze](https://www.parrot.com/fr/minidrones/parrot-airborne-night-blaze) wasn't detected, I figure out DRONE_PREFIXES is not complete. After adding 'Blaze_', everything work great !