### PR TITLE
Updated DRONE_PREFIXES to support Hydrofoil NewZ

### DIFF
--- a/lib/MiniDroneBtAdapter.js
+++ b/lib/MiniDroneBtAdapter.js
@@ -36,7 +36,7 @@ const CHARACTERISTIC_MAP = [
 
 // Drone IDs
 const MANUFACTURER_SERIALS = ['4300cf1900090100', '4300cf1909090100', '4300cf1907090100'];
-const DRONE_PREFIXES = ['RS_', 'Mars_', 'Travis_', 'Maclan_'];
+const DRONE_PREFIXES = ['RS_', 'Mars_', 'Travis_', 'Maclan_', 'NewZ_'];
 const MD_DEVICE_TYPE = 0x02;
 
 const FLIGHT_STATUSES = ['landed', 'taking off', 'hovering', 'flying',


### PR DESCRIPTION
Tested working with http://global.parrot.com/usa/products/minidrones/hydrofoil-drone/newz/ .