### PR TITLE
Update required to get Parrot Mambo Bebop working

### DIFF
--- a/lib/MiniDroneBtAdapter.js
+++ b/lib/MiniDroneBtAdapter.js
@@ -404,8 +404,8 @@ class MiniDroneBtAdapter extends EventEmitter {
         const matchesFilter = localName === this.options.droneFilter;
 
         let localNameMatch = false;
-        if(localName){
-                localNameMatch = matchesFilter || DRONE_PREFIXES.some((prefix) => localName.indexOf(prefix) >= 0);
+        if (localName) {
+            localNameMatch = matchesFilter || DRONE_PREFIXES.some((prefix) => localName.indexOf(prefix) >= 0);
         }
         const manufacturerMatch = manufacturer && (MANUFACTURER_SERIALS.indexOf(manufacturer) >= 0);
 

--- a/lib/MiniDroneBtAdapter.js
+++ b/lib/MiniDroneBtAdapter.js
@@ -403,7 +403,10 @@ class MiniDroneBtAdapter extends EventEmitter {
         const manufacturer = peripheral.advertisement.manufacturerData;
         const matchesFilter = localName === this.options.droneFilter;
 
-        const localNameMatch = matchesFilter || DRONE_PREFIXES.some((prefix) => localName.indexOf(prefix) >= 0);
+        let localNameMatch = false;
+        if(localName){
+                localNameMatch = matchesFilter || DRONE_PREFIXES.some((prefix) => localName.indexOf(prefix) >= 0);
+        }
         const manufacturerMatch = manufacturer && (MANUFACTURER_SERIALS.indexOf(manufacturer) >= 0);
 
           // Is TRUE according to droneFilter or if empty, for EITHER an "RS_" name OR manufacturer code.


### PR DESCRIPTION
This field was undefined for whatever reason, so handled for that case. It still finds that the other ID starts with Mambo_ so not a huge deal, but caused it to crash with my device (Parrot Mambo Bebop Minidrone). Thought you might like the update.